### PR TITLE
Make title required for events, not description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - lts/*
 script:
   - npm run lint
   - npm run test-with-coverage

--- a/controllers/eventRouter.js
+++ b/controllers/eventRouter.js
@@ -81,8 +81,8 @@ eventRouter.post('/', async (req, res) => {
     const { title, description, startdate, enddate, dives, target } = req.body
     const { user } = res.locals
 
-    if (!description) {
-      return res.status(400).json({ error: 'description missing' })
+    if (!title) {
+      return res.status(400).json({ error: 'title missing' })
     }
 
     const event = new Event({

--- a/controllers/eventRouter.js
+++ b/controllers/eventRouter.js
@@ -82,7 +82,7 @@ eventRouter.post('/', async (req, res) => {
     const { user } = res.locals
 
     if (!title) {
-      return res.status(400).json({ error: 'title missing' })
+      return res.status(400).json({ error: 'missing fields' })
     }
 
     const event = new Event({
@@ -170,7 +170,7 @@ eventRouter.put('/:id', async (req, res) => {
   try {
     const { title, description, startdate, enddate, admins, participants, pending, dives, target } = req.body
 
-    if (!description) {
+    if (!title) {
       return res.status(400).json({ error: 'missing fields' })
     }
 

--- a/controllers/userRouter.js
+++ b/controllers/userRouter.js
@@ -8,8 +8,6 @@ userRouter.get('/', async (req, res) => {
   try {
     const users = await User
       .find({})
-      .populate('events', { description: 1, startdate: 1, enddate: 1 })
-      .populate('dives', { user: 1, event: 1, latitude: 1, longitude: 1 })
 
     res.json(users.map(User.format))
   } catch (exception) {
@@ -21,8 +19,6 @@ userRouter.get('/', async (req, res) => {
 
 userRouter.get('/:id', async (req, res) => {
   const user = await User.findById(req.params.id)
-    .populate('events', { description: 1, startdate: 1, enddate: 1 })
-    .populate('dives', { user: 1, event: 1, latitude: 1, longitude: 1 })
 
   res.json(User.format(user))
 })

--- a/tests/_test_helper.js
+++ b/tests/_test_helper.js
@@ -15,7 +15,7 @@ const userObject = {
 
 const eventObjects = [
   {
-    'description': 'Suomen vanhin hylky, huono sää.',
+    'title': 'Suomen vanhin hylky, huono sää.',
     'startdate': '2019-01-15T13:03:22.014Z',
     '__v': 0,
     'enddate': '2019-01-15T14:12:25.128Z',

--- a/tests/event.test.js
+++ b/tests/event.test.js
@@ -27,7 +27,7 @@ describe('event tests', async () => {
       .get(`${config.apiUrl}/events`)
       .set('Authorization', `bearer ${token}`)
 
-    expect(response.body[0].description).toBe('Suomen vanhin hylky, huono sää.')
+    expect(response.body[0].title).toBe('Suomen vanhin hylky, huono sää.')
   })
 
   test('the id of the user of the event can be seen', async () => {
@@ -45,7 +45,7 @@ describe('event tests', async () => {
   test('event can be posted', async () => {
     const newEvent = {
 
-      'description': 'Haikaloja liikkeellä',
+      'title': 'Haikaloja liikkeellä',
       'startdate': '2019-02-15T13:03:22.014Z',
       'enddate': '2019-02-15T14:12:25.128Z',
       'target': null,
@@ -64,7 +64,7 @@ describe('event tests', async () => {
       .get(`${config.apiUrl}/events`)
       .set('Authorization', `bearer ${token}`)
 
-    const contents = response.body.map(r => r.description)
+    const contents = response.body.map(r => r.title)
 
     expect(contents).toContain('Haikaloja liikkeellä')
   })

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -27,22 +27,6 @@ describe('user tests', async () => {
 
     expect(response.body[0].username).toBe('SamiSukeltaja')
   })
-
-  test('content of the events of the user can be seen', async () => {
-    const response = await api
-      .get(`${config.apiUrl}/users`)
-      .set('Authorization', `bearer ${token}`)
-
-    expect(response.body[0].events[0].description).toBe('Suomen vanhin hylky, huono sää.')
-  })
-
-  test('content of the dives of the user can be seen', async () => {
-    const response = await api
-      .get(`${config.apiUrl}/users`)
-      .set('Authorization', `bearer ${token}`)
-
-    expect(response.body[0].dives[0].longitude).toBe(60.5525)
-  })
 })
 
 afterAll(async () => {


### PR DESCRIPTION
This is a minor fix to make title required for new events rather than description.