### PR TITLE
Return _id instead of id in all models

### DIFF
--- a/models/bouser.js
+++ b/models/bouser.js
@@ -13,10 +13,12 @@ const BOuserSchema = new mongoose.Schema({
 BOuserSchema.plugin(uniqueValidator)
 
 BOuserSchema.statics.format = (BOuser) => {
+  const { _id, username, admin } = BOuser
+
   return {
-    id: BOuser._id,
-    username: BOuser.username,
-    admin: BOuser.admin
+    _id,
+    username,
+    admin
   }
 }
 const BOUser = mongoose.model('BOUser', BOuserSchema)

--- a/models/dive.js
+++ b/models/dive.js
@@ -10,14 +10,16 @@ const diveSchema = new mongoose.Schema({
 })
 
 diveSchema.statics.format = (dive) => {
+  const { _id, startdate, enddate, user, event, latitude, longitude } = dive
+
   return {
-    id: dive._id,
-    startdate: dive.startdate,
-    enddate: dive.enddate,
-    user: dive.user,
-    event: dive.event,
-    latitude: dive.latitude,
-    longitude: dive.longitude
+    _id,
+    startdate,
+    enddate,
+    user,
+    event,
+    latitude,
+    longitude
   }
 }
 const Dive = mongoose.model('Dive', diveSchema)

--- a/models/event.js
+++ b/models/event.js
@@ -18,18 +18,20 @@ const eventSchema = new mongoose.Schema({
 })
 
 eventSchema.statics.format = (event) => {
+  const { _id, title, description, startdate, enddate, creator, admins, participants, pending, target, dives } = event
+
   return {
-    id: event._id,
-    title: event.title,
-    description: event.description,
-    startdate: event.startdate,
-    enddate: event.enddate,
-    creator: event.creator,
-    admins: event.admins,
-    participants: event.participants,
-    pending: event.pending,
-    target: event.target,
-    dives: event.dives
+    _id,
+    title,
+    description,
+    startdate,
+    enddate,
+    creator,
+    admins,
+    participants,
+    pending,
+    target,
+    dives
   }
 }
 const Event = mongoose.model('Event', eventSchema)

--- a/models/message.js
+++ b/models/message.js
@@ -10,14 +10,16 @@ const messageSchema = new mongoose.Schema({
 })
 
 messageSchema.statics.format = (message) => {
+  const { _id, sender, receivers, created, received, type, data } = message
+
   return {
-    id: message._id,
-    sender: message.sender,
-    receivers: message.receivers,
-    created: message.created,
-    received: message.received,
-    type: message.type,
-    data: message.data
+    _id,
+    sender,
+    receivers,
+    created,
+    received,
+    type,
+    data
   }
 }
 const Message = mongoose.model('message', messageSchema)

--- a/models/target.js
+++ b/models/target.js
@@ -20,10 +20,10 @@ const targetSchema = new mongoose.Schema({
 })
 
 targetSchema.statics.format = (target) => {
-  const { _id: id, name, latitude, longitude, type, depth, material, hylyt_id, hylyt_link, mj_id, mj_link } = target
+  const { _id, name, latitude, longitude, type, depth, material, hylyt_id, hylyt_link, mj_id, mj_link } = target
 
   return {
-    id,
+    _id,
     name,
     latitude,
     longitude,

--- a/models/user.js
+++ b/models/user.js
@@ -15,12 +15,14 @@ const userSchema = new mongoose.Schema({
 userSchema.plugin(uniqueValidator)
 
 userSchema.statics.format = (user) => {
+  const { _id, username, events, dives, messages } = user
+
   return {
-    id: user._id,
-    username: user.username,
-    events: user.events,
-    dives: user.dives,
-    messages: user.messages
+    _id,
+    username,
+    events,
+    dives,
+    messages
   }
 }
 const User = mongoose.model('User', userSchema)

--- a/tests/_test_helper.js
+++ b/tests/_test_helper.js
@@ -84,7 +84,7 @@ const postDive = async (event, token) => {
 
     'startdate': '2019-01-15T13:03:22.014Z',
     'enddate': '2019-01-15T14:12:25.128Z',
-    'event': `${event.id}`,
+    'event': `${event._id}`,
     'longitude': '60.5525',
     'latitude': '24.1232',
     '__v': 0

--- a/tests/event.test.js
+++ b/tests/event.test.js
@@ -39,7 +39,7 @@ describe('event tests', async () => {
       .get(`${config.apiUrl}/events`)
       .set('Authorization', `bearer ${token}`)
 
-    expect(response.body[0].creator._id).toBe(user.body[0].id)
+    expect(response.body[0].creator._id).toBe(user.body[0]._id)
   })
 
   test('event can be posted', async () => {
@@ -79,7 +79,7 @@ describe('event tests', async () => {
     eventModify.description = 'Modified content'
 
     await api
-      .put(`${config.apiUrl}/events/${eventModify.id}`)
+      .put(`${config.apiUrl}/events/${eventModify._id}`)
       .set('Authorization', `bearer ${token}`)
       .send(eventModify)
       .expect(200)
@@ -102,7 +102,7 @@ describe('event tests', async () => {
     const event = allEvents.body[1]
 
     const response = await api
-      .get(`${config.apiUrl}/events/${event.id}`)
+      .get(`${config.apiUrl}/events/${event._id}`)
       .set('Authorization', `bearer ${token}`)
 
     expect(response.body.description).toBe('Modified content')
@@ -116,7 +116,7 @@ describe('event tests', async () => {
     const event = allEvents.body[1]
 
     await api
-      .delete(`${config.apiUrl}/events/${event.id}`)
+      .delete(`${config.apiUrl}/events/${event._id}`)
       .set('Authorization', `bearer ${token}`)
       .expect(204)
 


### PR DESCRIPTION
This is to get consistent id naming from backend with populate and normal gets.

Might break things in frontend and/or BO, replace all `.id`s with `._id`.